### PR TITLE
Adding setter for the properties attribute of Arcs and Transitions

### DIFF
--- a/ocpa/objects/oc_petri_net/obj.py
+++ b/ocpa/objects/oc_petri_net/obj.py
@@ -109,6 +109,9 @@ class ObjectCentricPetriNet(object):
         def __get_in_arcs(self):
             return self.__in_arcs
 
+        def __set_properties(self, properties):
+            self.__properties = properties
+
         def __get_properties(self):
             return self.__properties
 
@@ -166,7 +169,7 @@ class ObjectCentricPetriNet(object):
         label = property(__get_label, __set_label)
         in_arcs = property(__get_in_arcs)
         out_arcs = property(__get_out_arcs)
-        properties = property(__get_properties)
+        properties = property(__get_properties, __set_properties)
         silent = property(__get_silent, __set_silent)
 
     class Arc(object):
@@ -199,6 +202,9 @@ class ObjectCentricPetriNet(object):
 
         def __get_variable(self):
             return self.__variable
+
+        def __set_properties(self, properties):
+            self.__properties = properties
 
         def __get_properties(self):
             return self.__properties
@@ -239,7 +245,7 @@ class ObjectCentricPetriNet(object):
         target = property(__get_target, __set_target)
         variable = property(__get_variable)
         weight = property(__get_weight, __set_weight)
-        properties = property(__get_properties)
+        properties = property(__get_properties, __set_properties)
 
     def __init__(self, name=None, places=None, transitions=None, arcs=None, properties=None, nets=None):
         self.__name = "" if name is None else name


### PR DESCRIPTION
Arcs and Transitions have an attribute called properties. By allowing developers to set this attribute after the initialisation of the object, developers have more freedome in using this attribute to store information on Arcs and Transitions that are helpful for their application.